### PR TITLE
bugfix-on-opening-admin-page

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -25,6 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
+require_once($CFG->dirroot . '/report/engagement/lib.php');
 require_once($CFG->dirroot . '/report/engagement/locallib.php');
 require_once($CFG->dirroot . '/mod/engagement/indicator/rendererbase.php');
 require_once($CFG->libdir . '/tablelib.php');


### PR DESCRIPTION
fixes error on opening default admin page moodle/report/engagement/manage_indicators.php?contextid=1 , namely
Exception - Call to undefined function report_engagement_is_core_indicator()
×Stack trace:
line 158 of /report/engagement/renderer.php: Error thrown
line 73 of /report/engagement/manage_indicators.php: call to report_engagement_renderer->display_indicator_list()